### PR TITLE
Point Cloud Receiving

### DIFF
--- a/SpeckleUnrealProject/Plugins/SpeckleUnreal/Source/SpeckleUnreal/Private/SpeckleUnrealManager.cpp
+++ b/SpeckleUnrealProject/Plugins/SpeckleUnreal/Source/SpeckleUnreal/Private/SpeckleUnrealManager.cpp
@@ -1,5 +1,4 @@
 #include "SpeckleUnrealManager.h"
-#pragma optimize("", off)
 
 // Sets default values
 ASpeckleUnrealManager::ASpeckleUnrealManager()
@@ -358,9 +357,11 @@ ALidarPointCloudActor* ASpeckleUnrealManager::CreatePointCloud(TSharedPtr<FJsonO
 	ALidarPointCloudActor* PointCloudInstance = (ALidarPointCloudActor*)ActorInstance;
 	
 	auto pointsField = obj->GetArrayField("points");
+	
 	if(pointsField.Num() > 0)
 	{
 		FString pointsId = pointsField[0]->AsObject()->GetStringField("referencedId");
+		FString bboxId = pointsField[0]->AsObject()->GetStringField("referencedId");
 		//FString colorsId = obj->GetArrayField("colors")[0]->AsObject()->GetStringField("referencedId");
 
 		TArray<TSharedPtr<FJsonValue>> ObjectPoints = SpeckleObjects[pointsId]->GetArrayField("data");
@@ -390,6 +391,8 @@ ALidarPointCloudActor* ASpeckleUnrealManager::CreatePointCloud(TSharedPtr<FJsonO
 
 		ULidarPointCloud* pointCloud = NewObject<ULidarPointCloud>();
 
+		pointCloud->Initialize(FBox(ParsedPoints));
+		
 		for (size_t i = 0; i < ParsedPoints.Num(); i++)
 		{
 			FLidarPointCloudPoint* point = new FLidarPointCloudPoint(ParsedPoints[i]);
@@ -398,7 +401,7 @@ ALidarPointCloudActor* ASpeckleUnrealManager::CreatePointCloud(TSharedPtr<FJsonO
 		}
 
 		pointCloud->RefreshBounds();
-		ULidarPointCloudComponent* t = PointCloudInstance->GetPointCloudComponent();
+
 		PointCloudInstance->SetPointCloud(pointCloud);
 	}
 

--- a/SpeckleUnrealProject/Plugins/SpeckleUnreal/Source/SpeckleUnreal/Private/SpeckleUnrealManager.cpp
+++ b/SpeckleUnrealProject/Plugins/SpeckleUnreal/Source/SpeckleUnreal/Private/SpeckleUnrealManager.cpp
@@ -375,26 +375,29 @@ ALidarPointCloudActor* ASpeckleUnrealManager::CreatePointCloud(const TSharedPtr<
 	const auto NumberOfPoints = ObjectPoints.Num() / 3;
 	
 	TArray<FVector> PointPositions;
-	//PointPositions.SetNum(NumberOfPoints);
+	PointPositions.SetNum(NumberOfPoints);
 
-	for (int j = 0; j + 2 < ObjectPoints.Num(); j += 3) 
+	for (int i = 0, j = 0; i < NumberOfPoints; i++, j += 3) 
 	{
-		PointPositions.Add(FVector
+		PointPositions[i] = FVector
 		(
-			(float)(ObjectPoints[j].Get()->AsNumber()),
-			(float)(ObjectPoints[j + 1].Get()->AsNumber()),
-			(float)(ObjectPoints[j + 2].Get()->AsNumber())
-		));
+			static_cast<float>(ObjectPoints[j].Get()->AsNumber()),
+			static_cast<float>(ObjectPoints[j + 1].Get()->AsNumber()),
+			static_cast<float>(ObjectPoints[j + 2].Get()->AsNumber())
+			
+		) * ScaleFactor;
 	}
 	//TODO parse point colors
 
 
 	TArray<FLidarPointCloudPoint> ParsedPoints;
-	//ParsedPoints.SetNum(NumberOfPoints);
+	ParsedPoints.SetNum(NumberOfPoints);
 
+	int i = 0;
 	for(FVector Position : PointPositions)
 	{
-		ParsedPoints.Add(FLidarPointCloudPoint(Position));
+		ParsedPoints[i] = FLidarPointCloudPoint(Position);
+		i++;
 	}
 	
 	ULidarPointCloud* PointCloud = NewObject<ULidarPointCloud>();

--- a/SpeckleUnrealProject/Plugins/SpeckleUnreal/Source/SpeckleUnreal/Public/SpeckleUnrealManager.h
+++ b/SpeckleUnrealProject/Plugins/SpeckleUnreal/Source/SpeckleUnreal/Public/SpeckleUnrealManager.h
@@ -12,6 +12,13 @@
 // web requests
 #include "Runtime/Online/HTTP/Public/Http.h"
 
+// point clouds
+#include "LidarPointCloudRuntime/Public/LidarPointCloud.h"
+#include "LidarPointCloudRuntime/Public/LidarPointCloudActor.h"
+#include "LidarPointCloudRuntime/Public/LidarPointCloudShared.h"
+#include "LidarPointCloudRuntime/Public/LidarPointCloudSettings.h"
+#include "Math/Vector.h"
+
 #include "SpeckleUnrealMesh.h"
 #include "SpeckleUnrealLayer.h"
 #include "GameFramework/Actor.h"
@@ -88,10 +95,16 @@ protected:
 	TMap<FString, ASpeckleUnrealMesh*> CreatedSpeckleMeshes;
 	TMap<FString, ASpeckleUnrealMesh*> InProgressSpeckleMeshes;
 
+	TMap<FString, ALidarPointCloudActor*> CreatedLidarPointClouds;
+	TMap<FString, ALidarPointCloudActor*> InProgressLidarPointClouds;
+
 	ASpeckleUnrealMesh* GetExistingMesh(const FString &objectId);
 
 	void ImportObjectFromCache(const TSharedPtr<FJsonObject> speckleObject);
 
 	UMaterialInterface* CreateMaterial(TSharedPtr<FJsonObject>);
 	ASpeckleUnrealMesh* CreateMesh(TSharedPtr<FJsonObject>, UMaterialInterface *explicitMaterial = nullptr);
+	ALidarPointCloudActor* CreatePointCloud(TSharedPtr<FJsonObject>);
+
+	static float ParseScaleFactor(const FString units);
 };

--- a/SpeckleUnrealProject/Plugins/SpeckleUnreal/Source/SpeckleUnreal/SpeckleUnreal.Build.cs
+++ b/SpeckleUnrealProject/Plugins/SpeckleUnreal/Source/SpeckleUnreal/SpeckleUnreal.Build.cs
@@ -11,6 +11,7 @@ public class SpeckleUnreal : ModuleRules
 		PublicIncludePaths.AddRange(
 			new string[] {
 				// ... add public include paths required here ...
+				"LidarPointCloudRuntime/Public",
 			}
 			);
 				
@@ -29,7 +30,8 @@ public class SpeckleUnreal : ModuleRules
 				"Http", 
 				"Json", 
 				"JsonUtilities", 
-				"ProceduralMeshComponent"
+				"ProceduralMeshComponent",
+				"LidarPointCloudRuntime",
 				// ... add other public dependencies that you statically link with here ...
 			}
 			);

--- a/SpeckleUnrealProject/Plugins/SpeckleUnreal/SpeckleUnreal.uplugin
+++ b/SpeckleUnrealProject/Plugins/SpeckleUnreal/SpeckleUnreal.uplugin
@@ -25,6 +25,10 @@
 		{
 			"Name": "ProceduralMeshComponent",
 			"Enabled": true
+		},
+		{
+			"Name": "LidarPointCloud",
+			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
See issue #9.
This PR adds support for importing `Objects.Geometry.Pointcloud` into Unreal as `ALidarPointCloudActor`s

### Limitations
1. This does add a dependency of the first party [Lidar Point Cloud Plugin](https://docs.unrealengine.com/4.26/en-US/WorkingWithContent/LidarPointCloudPlugin/).
1. Does not currently support point color data.
1. Does not support sending (although this is true for meshes as well)