### PR TITLE
Fixed issue with materials assets not being properly created.

### DIFF
--- a/Source/SpeckleUnreal/Private/NativeActors/SpeckleUnrealProceduralMesh.cpp
+++ b/Source/SpeckleUnreal/Private/NativeActors/SpeckleUnrealProceduralMesh.cpp
@@ -77,11 +77,8 @@ UMaterialInterface* ASpeckleUnrealProceduralMesh::GetMaterial(const URenderMater
     UMaterialInterface* MaterialBase = SpeckleMaterial->Opacity >= 1
         ? Manager->BaseMeshOpaqueMaterial
         : Manager->BaseMeshTransparentMaterial;
-
-    const FString PackagePath = FPaths::Combine(TEXT("/Game/Speckle"), Manager->StreamID, TEXT("Materials"), SpeckleMaterial->Id);
-    UPackage* Package = CreatePackage(*PackagePath);
 	
-    UMaterialInstanceDynamic* DynMaterial = UMaterialInstanceDynamic::Create(MaterialBase, Package, FName(SpeckleMaterial->Name));
+    UMaterialInstanceDynamic* DynMaterial = UMaterialInstanceDynamic::Create(MaterialBase, Manager, FName(SpeckleMaterial->Name));
     
     DynMaterial->SetFlags(RF_Public);
 	
@@ -92,12 +89,6 @@ UMaterialInterface* ASpeckleUnrealProceduralMesh::GetMaterial(const URenderMater
     DynMaterial->SetVectorParameterValue("EmissiveColor", SpeckleMaterial->Emissive);
 	
     Manager->ConvertedMaterials.Add(SpeckleMaterial->Id, DynMaterial);
-
-    if (GetWorld()->WorldType == EWorldType::PIE)
-    {
-        FAssetRegistryModule::AssetCreated(DynMaterial);
-    }
     
     return DynMaterial;
-	
 }

--- a/Source/SpeckleUnreal/Public/NativeActors/SpeckleUnrealStaticMesh.h
+++ b/Source/SpeckleUnreal/Public/NativeActors/SpeckleUnrealStaticMesh.h
@@ -17,6 +17,9 @@ class SPECKLEUNREAL_API ASpeckleUnrealStaticMesh : public ASpeckleUnrealActor, p
 {
 	GENERATED_BODY()
 	
+protected:
+	virtual UStaticMesh* MeshToNative(UObject* Outer, const UMesh* SpeckleMesh, ASpeckleUnrealManager* Manager);
+	
 public:
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadWrite)
@@ -33,7 +36,8 @@ public:
 		
 	// Sets default values for this actor's properties
 	ASpeckleUnrealStaticMesh();
-	
+
+
 	virtual void SetMesh_Implementation(const UMesh* SpeckleMesh, ASpeckleUnrealManager* Manager) override;
 	
 	UFUNCTION(BlueprintCallable)

--- a/Source/SpeckleUnreal/Public/SpeckleUnrealManager.h
+++ b/Source/SpeckleUnreal/Public/SpeckleUnrealManager.h
@@ -119,7 +119,8 @@ protected:
 	
 
 	TMap<FString, TSharedPtr<FJsonObject>> SpeckleObjects;
-	
+
+	UPROPERTY()
 	TArray<UObject*> CreatedObjectsCache;
 	TArray<UObject*> InProgressObjectsCache;
 	


### PR DESCRIPTION
Switch to using `UMaterialInstanceConstant` for Editor conversion. This resolves #29 and resolves #35
Added some logic to reuse static mesh assets, this resolves #32.