### PR TITLE
Ue5 objects fix

### DIFF
--- a/Source/SpeckleUnreal/Public/Objects/Base.h
+++ b/Source/SpeckleUnreal/Public/Objects/Base.h
@@ -18,7 +18,7 @@ class SPECKLEUNREAL_API UBase : public UObject
 public:
 	GENERATED_BODY()
 	
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	FString Id;
 	
 	//UPROPERTY(BlueprintReadOnly)

--- a/Source/SpeckleUnreal/Public/Objects/Base.h
+++ b/Source/SpeckleUnreal/Public/Objects/Base.h
@@ -24,10 +24,10 @@ public:
 	//UPROPERTY(BlueprintReadOnly)
 	//TMap<FString, FString> Properties; //TODO figure out how I'm going to do custom properties
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	FString Units;
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	FString SpeckleType;
 	
 	virtual void Parse(const TSharedPtr<FJsonObject> Obj, const ASpeckleUnrealManager* _)

--- a/Source/SpeckleUnreal/Public/Objects/Mesh.h
+++ b/Source/SpeckleUnreal/Public/Objects/Mesh.h
@@ -18,22 +18,22 @@ class SPECKLEUNREAL_API UMesh : public UBase
 	GENERATED_BODY()
 	
 public:
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	TArray<FVector> Vertices;
 	
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	TArray<int32> Faces;
 	
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	TArray<FVector2D> TextureCoordinates;
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	TArray<FColor> VertexColors;
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	FMatrix Transform;
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	URenderMaterial* RenderMaterial;
 	
 	virtual void Parse(const TSharedPtr<FJsonObject> Obj, const ASpeckleUnrealManager* Manager) override;

--- a/Source/SpeckleUnreal/Public/Objects/PointCloud.h
+++ b/Source/SpeckleUnreal/Public/Objects/PointCloud.h
@@ -16,13 +16,13 @@ class SPECKLEUNREAL_API UPointCloud : public UBase
 
 public:
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	TArray<FVector> Points;
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	TArray<FColor> Colors;
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Speckle|Objects")
 	TArray<float> Sizes;
 
 	virtual void Parse(const TSharedPtr<FJsonObject> Obj, const ASpeckleUnrealManager* Manager) override;


### PR DESCRIPTION
Adds category tags to certain `UPROPERTY` fields, this removes compile warnings in UE5