### PR TITLE
Fixed issue with receiving nested arrays from grashopper

### DIFF
--- a/Source/SpeckleUnreal/Private/Conversion/SpeckleConverterComponent.cpp
+++ b/Source/SpeckleUnreal/Private/Conversion/SpeckleConverterComponent.cpp
@@ -78,41 +78,42 @@ AActor* USpeckleConverterComponent::RecursivelyConvertToNative_Internal(AActor* 
 	Task->EnterProgressFrame(1);
 	if(Task->ShouldCancel()) return AOwner;
 	
-	ConvertChildren(NextOwner, Base, LocalTransport, Task, OutActors);
-	return AOwner;
-}
-
-void USpeckleConverterComponent::ConvertChildren(AActor* AOwner, const UBase* Base, const TScriptInterface<ITransport>& LocalTransport, FSlowTask* Task, TArray<AActor*>& OutActors)
-{
 	//Convert Children
 	TMap<FString, TSharedPtr<FJsonValue>> PotentialChildren = Base->DynamicProperties;
 	
-	for (const auto& Kv : PotentialChildren)
+	for (const auto& Kvp : PotentialChildren)
 	{
-		if(Task->ShouldCancel()) return;
+		if(Task->ShouldCancel()) break;
 		
-		const TSharedPtr<FJsonObject>* SubObjectPtr;
-		if (Kv.Value->TryGetObject(SubObjectPtr))
-		{
-			const UBase* Child = USpeckleSerializer::DeserializeBase(*SubObjectPtr, LocalTransport);
-			RecursivelyConvertToNative_Internal(AOwner, Child, LocalTransport, Task, OutActors);
-			continue;
-		}
+		ConvertChild(Kvp.Value, AOwner, LocalTransport, Task, OutActors);
+	}
+	return AOwner;
+}
 
-		const TArray<TSharedPtr<FJsonValue>>* SubArrayPtr;
-		if (Kv.Value->TryGetArray(SubArrayPtr))
+void USpeckleConverterComponent::ConvertChild(const TSharedPtr<FJsonValue> Object, AActor* AOwner,
+                                              const TScriptInterface<ITransport>& LocalTransport, FSlowTask* Task,
+                                              TArray<AActor*>& OutActors)
+{
+	//Handle child object
+	const TSharedPtr<FJsonObject>* ChildObj;
+	if (Object->TryGetObject(ChildObj))
+	{
+		const UBase* Child = USpeckleSerializer::DeserializeBase(*ChildObj, LocalTransport);
+		RecursivelyConvertToNative_Internal(AOwner, Child, LocalTransport, Task, OutActors);
+		return;
+	}
+
+	//Handle child array object
+	const TArray<TSharedPtr<FJsonValue>>* ChildArr;
+	if (Object->TryGetArray(ChildArr))
+	{
+		for (const auto v : *ChildArr)
 		{
-			for (const auto ArrayElement : *SubArrayPtr)
-			{
-				const TSharedPtr<FJsonObject>* ArraySubObjPtr;
-				if (!ArrayElement->TryGetObject(ArraySubObjPtr)) continue;
-				
-				const UBase* Child = USpeckleSerializer::DeserializeBase(*ArraySubObjPtr, LocalTransport);
-				RecursivelyConvertToNative_Internal(AOwner, Child, LocalTransport, Task, OutActors);
-			}
+			ConvertChild(v, AOwner, LocalTransport, Task, OutActors);
 		}
 	}
-}
+};
+	
 
 void USpeckleConverterComponent::AttachConvertedToOwner(AActor* AOwner, const UBase* Base, UObject* Converted)
 {

--- a/Source/SpeckleUnreal/Private/Tests/Transports/MemoryTransportTest.cpp
+++ b/Source/SpeckleUnreal/Private/Tests/Transports/MemoryTransportTest.cpp
@@ -1,0 +1,62 @@
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
+
+#include "Misc/AutomationTest.h"
+#include "Objects/Base.h"
+#include "Transports/MemoryTransport.h"
+
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMemoryTransportTest, "SpeckleUnreal.Transports.MemoryTransport", EAutomationTestFlags::EditorContext | EAutomationTestFlags::SmokeFilter)
+
+
+bool FMemoryTransportTest::RunTest(const FString& Parameters)
+{
+	UMemoryTransport* Transport = UMemoryTransport::CreateEmptyMemoryTransport();
+	// Test Construction
+	{
+		TestNotNull(TEXT("Constructed object"), Transport);
+		TestTrue(TEXT("Constructed object is valid"), IsValid(Transport));
+	}
+	
+	TSharedPtr<FJsonObject> MockObj = MakeShareable(new FJsonObject());
+	FString TestId = TEXT("testidlalalala");
+	FString TestPayloadName = TEXT("Playload");
+	FString TestPayload = TEXT("MyPayloadValue!");
+	MockObj->SetStringField(TestPayloadName, TestPayload);
+	
+	// Test Save
+	{
+		Transport->SaveObject(TestId, MockObj);
+		TestTrue(TEXT("Transport with save object to HasObject"), Transport->HasObject(TestId));
+		
+		auto Value = Transport->GetSpeckleObject(TestId);
+		TestNotNull(TEXT("Return of getting saved object"), Value.Get());
+		TestEqual(TEXT("Return of getting saved object"), Value, MockObj);
+		TestTrue(TEXT("Returned object to have payload"), Value->HasField(TestPayloadName));
+		TestEqual(TEXT("Returned object's playload"), Value->GetStringField(TestPayloadName), TestPayload);
+	}
+
+	// Test Ids are missing
+	{
+		TArray<FString> MissingIds = {
+			TEXT("NoObjectsWithThisId"),
+			TEXT("testidla"),
+			TEXT("testidlalalalaextrala"),
+			TEXT("testidrararara"),
+			TEXT(""),
+		};
+		
+		for(const FString& Id : MissingIds)
+		{
+			TestFalse(TEXT("transport has unknown id -") + Id, Transport->HasObject(Id));
+			auto ValueM = Transport->GetSpeckleObject(Id);
+			TestNull(TEXT("return of unknown id -") + Id, ValueM.Get());
+		}
+	}
+	
+	return true;
+}
+
+
+#endif

--- a/Source/SpeckleUnreal/Private/Tests/Transports/ServerTransportTest.cpp
+++ b/Source/SpeckleUnreal/Private/Tests/Transports/ServerTransportTest.cpp
@@ -1,0 +1,25 @@
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
+
+#include "Misc/AutomationTest.h"
+#include "Objects/Base.h"
+#include "Transports/ServerTransport.h"
+
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FServerTransportTest, "SpeckleUnreal.Transports.ServerTransport", EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+
+bool FServerTransportTest::RunTest(const FString& Parameters)
+{
+	FString ServerUrl = TEXT("https://example.com");
+	FString StreamId = TEXT("1234");
+	FString Token = TEXT("MyAuthToken");
+	auto Transport = UServerTransport::CreateServerTransport(ServerUrl, StreamId, Token);
+	
+	
+	return true;
+}
+
+
+#endif

--- a/Source/SpeckleUnreal/Public/API/Client.h
+++ b/Source/SpeckleUnreal/Public/API/Client.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 //#pragma once
 

--- a/Source/SpeckleUnreal/Public/API/Operations/ReceiveOperation.h
+++ b/Source/SpeckleUnreal/Public/API/Operations/ReceiveOperation.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/API/Operations/SendOperation.h
+++ b/Source/SpeckleUnreal/Public/API/Operations/SendOperation.h
@@ -1,4 +1,4 @@
-﻿// // Fill out your copyright notice in the Description page of Project Settings.
+﻿// // Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 //
 // #pragma once
 //

--- a/Source/SpeckleUnreal/Public/API/SpeckleSerializer.h
+++ b/Source/SpeckleUnreal/Public/API/SpeckleSerializer.h
@@ -1,4 +1,6 @@
-﻿#pragma once
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
+
+#pragma once
 
 #include "CoreMinimal.h"
 #include "Kismet/BlueprintFunctionLibrary.h"

--- a/Source/SpeckleUnreal/Public/Conversion/Converters/AggregateConverter.h
+++ b/Source/SpeckleUnreal/Public/Conversion/Converters/AggregateConverter.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Conversion/Converters/BlockConverter.h
+++ b/Source/SpeckleUnreal/Public/Conversion/Converters/BlockConverter.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Conversion/Converters/MaterialConverter.h
+++ b/Source/SpeckleUnreal/Public/Conversion/Converters/MaterialConverter.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Conversion/Converters/PointCloudConverter.h
+++ b/Source/SpeckleUnreal/Public/Conversion/Converters/PointCloudConverter.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Conversion/Converters/ProceduralMeshConverter.h
+++ b/Source/SpeckleUnreal/Public/Conversion/Converters/ProceduralMeshConverter.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Conversion/Converters/StaticMeshConverter.h
+++ b/Source/SpeckleUnreal/Public/Conversion/Converters/StaticMeshConverter.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Conversion/SpeckleConverter.h
+++ b/Source/SpeckleUnreal/Public/Conversion/SpeckleConverter.h
@@ -1,5 +1,4 @@
-﻿
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Conversion/SpeckleConverterComponent.h
+++ b/Source/SpeckleUnreal/Public/Conversion/SpeckleConverterComponent.h
@@ -43,7 +43,7 @@ protected:
 
 	virtual AActor* RecursivelyConvertToNative_Internal(AActor* AOwner, const UBase* Base, const TScriptInterface<ITransport>& LocalTransport, FSlowTask* Task, TArray<AActor*>& OutActors);
 	
-	virtual void ConvertChildren(AActor* AOwner, const UBase* Base, const TScriptInterface<ITransport>& LocalTransport, FSlowTask* Task, TArray<AActor*>& OutActors);
+	virtual void ConvertChild(const TSharedPtr<FJsonValue> Object, AActor* AOwner, const TScriptInterface<ITransport>& LocalTransport, FSlowTask* Task, TArray<AActor*>& OutActors);
 	
 	UFUNCTION(BlueprintCallable, Category="Speckle|Conversion")
 	virtual void AttachConvertedToOwner(AActor* AOwner, const UBase* Base, UObject* Converted);

--- a/Source/SpeckleUnreal/Public/Conversion/SpeckleConverterComponent.h
+++ b/Source/SpeckleUnreal/Public/Conversion/SpeckleConverterComponent.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/LogSpeckle.h
+++ b/Source/SpeckleUnreal/Public/LogSpeckle.h
@@ -1,4 +1,4 @@
-﻿// Copyright Epic Games, Inc. All Rights Reserved.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 #include "CoreMinimal.h"

--- a/Source/SpeckleUnreal/Public/Mixpanel.h
+++ b/Source/SpeckleUnreal/Public/Mixpanel.h
@@ -1,4 +1,6 @@
-﻿#pragma once
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
+
+#pragma once
 
 #include "CoreMinimal.h"
 

--- a/Source/SpeckleUnreal/Public/Objects/Base.h
+++ b/Source/SpeckleUnreal/Public/Objects/Base.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Objects/DisplayValueElement.h
+++ b/Source/SpeckleUnreal/Public/Objects/DisplayValueElement.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Objects/Geometry/Mesh.h
+++ b/Source/SpeckleUnreal/Public/Objects/Geometry/Mesh.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Objects/Geometry/PointCloud.h
+++ b/Source/SpeckleUnreal/Public/Objects/Geometry/PointCloud.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Objects/ObjectModelRegistry.h
+++ b/Source/SpeckleUnreal/Public/Objects/ObjectModelRegistry.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Objects/Other/BlockInstance.h
+++ b/Source/SpeckleUnreal/Public/Objects/Other/BlockInstance.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Objects/Other/RenderMaterial.h
+++ b/Source/SpeckleUnreal/Public/Objects/Other/RenderMaterial.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Objects/Other/View3D.h
+++ b/Source/SpeckleUnreal/Public/Objects/Other/View3D.h
@@ -1,4 +1,4 @@
-﻿// Copyright AEC Systems Ltd
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Objects/Utils/SpeckleObjectUtils.h
+++ b/Source/SpeckleUnreal/Public/Objects/Utils/SpeckleObjectUtils.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/SpeckleUnreal.h
+++ b/Source/SpeckleUnreal/Public/SpeckleUnreal.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/SpeckleUnrealManager.h
+++ b/Source/SpeckleUnreal/Public/SpeckleUnrealManager.h
@@ -1,3 +1,5 @@
+// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
+
 #pragma once
 
 #include "GameFramework/Actor.h"

--- a/Source/SpeckleUnreal/Public/Transports/MemoryTransport.h
+++ b/Source/SpeckleUnreal/Public/Transports/MemoryTransport.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Transports/ServerTransport.h
+++ b/Source/SpeckleUnreal/Public/Transports/ServerTransport.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnreal/Public/Transports/Transport.h
+++ b/Source/SpeckleUnreal/Public/Transports/Transport.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnrealEditor/Public/Conversion/ConverterActions.h
+++ b/Source/SpeckleUnrealEditor/Public/Conversion/ConverterActions.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnrealEditor/Public/Conversion/ConverterFactory.h
+++ b/Source/SpeckleUnrealEditor/Public/Conversion/ConverterFactory.h
@@ -1,4 +1,4 @@
-﻿// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/Source/SpeckleUnrealEditor/Public/SpeckleUnrealEditorModule.h
+++ b/Source/SpeckleUnrealEditor/Public/SpeckleUnrealEditorModule.h
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright 2022 AEC Systems, Licensed under the Apache License, Version 2.0
 
 #pragma once
 

--- a/SpeckleUnreal.uplugin
+++ b/SpeckleUnreal.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "2.5.0",
+	"VersionName": "2.5.1",
 	"FriendlyName": "SpeckleUnreal",
 	"Description": "Speckle is an open source data platform for Architecture, Engineering, and Construction. It has been open sourced under the MIT license, is customizable, and available in the cloud or via a self-hosted server. It allows users to exchange data between various AEC modelling and content creation platforms.",
 	"Category": "AEC",
@@ -18,12 +18,14 @@
 		{
 			"Name": "SpeckleUnreal",
 			"Type": "Runtime",
-			"LoadingPhase": "Default"
+			"LoadingPhase": "Default",
+			"WhitelistPlatforms": [ "Win64", "Linux", "Mac", "IOS", "Android" ]
 		},
 		{
 			"Name": "SpeckleUnrealEditor",
 			"Type": "Editor",
-			"LoadingPhase": "PostEngineInit"
+			"LoadingPhase": "PostEngineInit",
+			"WhitelistPlatforms": [ "Win64", "Linux", "Mac" ]
 		}
 	],
 	"Plugins": [


### PR DESCRIPTION
Depending on the structure of data sent from grasshopper,
it is possible to see data that has nested lists of child objects.
Currently, we only convert a single layer deep.