### PR TITLE
Buiding on UE5.1-preview 2 now works.

### DIFF
--- a/.pluginconfig/4.26/SpeckleUnreal.uplugin
+++ b/.pluginconfig/4.26/SpeckleUnreal.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "2.8.0",
+	"VersionName": "2.9.0",
 	"FriendlyName": "Speckle Unreal",
 	"Description": "Speckle is an open source data platform for Architecture, Engineering, and Construction. It has been open sourced under the Apache License 2.0, is customizable, and available in the cloud or via a self-hosted server. It allows users to exchange data between various AEC modelling and content creation platforms.",
 	"Category": "AEC",

--- a/.pluginconfig/4.27/SpeckleUnreal.uplugin
+++ b/.pluginconfig/4.27/SpeckleUnreal.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "2.8.0",
+	"VersionName": "2.9.0",
 	"FriendlyName": "Speckle Unreal",
 	"Description": "Speckle is an open source data platform for Architecture, Engineering, and Construction. It has been open sourced under the Apache License 2.0, is customizable, and available in the cloud or via a self-hosted server. It allows users to exchange data between various AEC modelling and content creation platforms.",
 	"Category": "AEC",

--- a/.pluginconfig/5.0/SpeckleUnreal.uplugin
+++ b/.pluginconfig/5.0/SpeckleUnreal.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "2.8.0",
+	"VersionName": "2.9.0",
 	"FriendlyName": "Speckle Unreal",
 	"Description": "Speckle is an open source data platform for Architecture, Engineering, and Construction. It has been open sourced under the Apache License 2.0, is customizable, and available in the cloud or via a self-hosted server. It allows users to exchange data between various AEC modelling and content creation platforms.",
 	"Category": "AEC",

--- a/Source/SpeckleUnreal/Public/API/Models/SpeckleBranch.h
+++ b/Source/SpeckleUnreal/Public/API/Models/SpeckleBranch.h
@@ -35,7 +35,7 @@ struct FSpeckleBranches
 	GENERATED_BODY();
 	
 	UPROPERTY(BlueprintReadWrite, Category="Speckle|API Models")
-	int32 TotalCount;
+	int32 TotalCount = 0;
 	
 	UPROPERTY(BlueprintReadWrite, Category="Speckle|API Models")
 	FString Cursor;

--- a/Source/SpeckleUnreal/Public/API/Models/SpeckleCommit.h
+++ b/Source/SpeckleUnreal/Public/API/Models/SpeckleCommit.h
@@ -55,7 +55,7 @@ struct FSpeckleCommits
 	GENERATED_BODY();
 	
 	UPROPERTY(BlueprintReadWrite, Category="Speckle|API Models")
-	int32 TotalCount;
+	int32 TotalCount = 0;
 	
 	UPROPERTY(BlueprintReadWrite, Category="Speckle|API Models")
 	FString Cursor;

--- a/Source/SpeckleUnreal/Public/API/Models/SpeckleStream.h
+++ b/Source/SpeckleUnreal/Public/API/Models/SpeckleStream.h
@@ -27,7 +27,7 @@ struct FSpeckleStream
 	FString Description;
 
 	UPROPERTY(BlueprintReadOnly, Category="Speckle|API Models")
-	bool IsPublic;
+	bool IsPublic = false;
 
 	UPROPERTY(BlueprintReadOnly, Category="Speckle|API Models")
 	FString Role;
@@ -67,7 +67,7 @@ struct FSpeckleStreams
 	GENERATED_BODY();
 	
 	UPROPERTY(BlueprintReadWrite, Category="Speckle|API Models")
-	int32 TotalCount;
+	int32 TotalCount = 0;
 	
 	UPROPERTY(BlueprintReadWrite, Category="Speckle|API Models")
 	FString Cursor;

--- a/Source/SpeckleUnrealEditor/Private/SpeckleUnrealEditorModule.cpp
+++ b/Source/SpeckleUnrealEditor/Private/SpeckleUnrealEditorModule.cpp
@@ -33,7 +33,8 @@ void FSpeckleUnrealEditorModule::StartupModule()
 
 			// Create FConverterActions for USpeckleConverter types
 			if ( Class->ImplementsInterface(USpeckleConverter::StaticClass())
-				&& !Class->HasAnyClassFlags(CLASS_Abstract))
+				&& !Class->HasAnyClassFlags(CLASS_Abstract)
+				&& !Class->GetFName().ToString().Contains(TEXT("REINST"))) //Ignore hot-reloaded BPs
 			{
 				AssetTools.RegisterAssetTypeActions(MakeShareable(new FConverterActions(Class, SpeckleAssetCategoryBit)));
 			}


### PR DESCRIPTION
Fixed an issue in UE5.1, where the temporary "REINST" blueprint classes were being picked up by our asset actions.
I *think* this may simply be a bug with UE5.1, but is something a simple check fixes.