### PR TITLE
Fixed crash when overriding material by Name

### DIFF
--- a/Source/SpeckleUnreal/Private/Conversion/Converters/MaterialConverter.cpp
+++ b/Source/SpeckleUnreal/Private/Conversion/Converters/MaterialConverter.cpp
@@ -78,7 +78,7 @@ bool UMaterialConverter::TryGetOverride(const URenderMaterial* SpeckleMaterial, 
 	{
 		if(ensureAlways(IsValid(Mat)) && Mat->GetName() == Name)
 		{
-			OutMaterial = MaterialOverridesById[MaterialID];
+			OutMaterial = *MaterialOverridesByName.Find(Mat);
 			return true;
 		}
 	}


### PR DESCRIPTION
Currently a crash will occur when using the Material Overrides by Name feature of the MaterialConverter.
Variable `MaterialOverridesById` was used by mistake, while `MaterialOverridesByName` should have been used instead.

This pull request corrects this issue.

_Feauture suggestion :_ 
I'd also like to suggest an alternative way of using `MaterialOverridesByName` that I have in mind.
Instead of `MaterialOverridesByName` being a TSet it could as well be a TMap like `MaterialOverridesById` with SpeckleMaterial Name as the key.
This way designers won't have to exactly match the name of an UE material asset to have the same name as the speckle material mentioned allowing for more flexibility (e.g. no need to rename a material asset just to test how it looks, the same material can be applied to multiple SpeckleMaterial Names without needing a separate .uasset).
As a bonus the code would not need to iterate anymore through the entire TSet looking for a matching material name but just lookup the name in the TMap similar to how `MaterialOverridesById` does, improving code readability a bit in my opinion.
If you are interested in that feature let me know and I can create a new pull request for it.