### PR TITLE
Fixed warning for UE5.4 - converted string literals to  TEXT macro

### DIFF
--- a/Source/SpeckleUnreal/Private/API/ClientAPI.cpp
+++ b/Source/SpeckleUnreal/Private/API/ClientAPI.cpp
@@ -27,7 +27,7 @@ void FClientAPI::MakeGraphQLRequest(const FString& ServerUrl, const FString& Aut
 		if(!GetResponseAsJSON(Response, RequestLogName, Obj, OnError)) return;
 
 		const TSharedPtr<FJsonObject>* DataObjectPtr;
-		if(!Obj->TryGetObjectField("data", DataObjectPtr))
+		if(!Obj->TryGetObjectField(TEXT("data"), DataObjectPtr))
 		{
 			OnError(TEXT("%s responce was invalid, expected to find a \"data\" property in response"));
 			return;
@@ -89,7 +89,7 @@ void FClientAPI::MakeGraphQLRequest(const FString& ServerUrl, const FString& Aut
 		UE_LOG(LogSpeckle, Warning, TEXT("POST Request %s to %s failed to send"), *RequestLogName, *Request->GetURL() );
 	}
 	
-	FAnalytics::TrackEvent(Request->GetURL(), "NodeRun", TMap<FString, FString> { {"name", __FUNCTION__}});
+	FAnalytics::TrackEvent(Request->GetURL(), TEXT("NodeRun"), TMap<FString, FString> { {TEXT("name"), __FUNCTION__}});
 }
 
 
@@ -124,14 +124,14 @@ FHttpRequestRef FClientAPI::CreatePostRequest(const FString& ServerUrl, const FS
 {
 	FHttpRequestRef Request = FHttpModule::Get().CreateRequest();
 
-	Request->SetURL(ServerUrl + "/graphql");
+	Request->SetURL(ServerUrl + TEXT("/graphql"));
 	Request->SetVerb(TEXT("POST"));
-	Request->SetHeader("Accept-Encoding", Encoding);
-	Request->SetHeader("Content-Type", TEXT("application/json"));
+	Request->SetHeader(TEXT("Accept-Encoding"), Encoding);
+	Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
 	if(!AuthToken.IsEmpty())
-		Request->SetHeader("Authorization","Bearer " + AuthToken);
-	Request->SetHeader("apollographql-client-name", "Unreal Engine");
-	Request->SetHeader("apollographql-client-version", SPECKLE_CONNECTOR_VERSION);
+		Request->SetHeader(TEXT("Authorization"), FString::Printf(TEXT("Bearer %s"), *AuthToken));
+	Request->SetHeader(TEXT("apollographql-client-name"), TEXT("Unreal Engine"));
+	Request->SetHeader(TEXT("apollographql-client-version"), SPECKLE_CONNECTOR_VERSION);
 	Request->SetContentAsString(PostPayload);
 
 	return Request;
@@ -178,10 +178,10 @@ bool FClientAPI::CheckForOperationErrors(const TSharedPtr<FJsonObject> GraphQLRe
 			FString Message;
 			const TSharedPtr<FJsonObject>* ErrorObject;
 			bool HadMessage = e->TryGetObject(ErrorObject)
-				&& (*ErrorObject)->TryGetStringField("message", Message);
+				&& (*ErrorObject)->TryGetStringField(TEXT("message"), Message);
 			if(!HadMessage)
 			{
-				Message = "An operation error occured but had no message!\n";
+				Message = TEXT("An operation error occured but had no message!\n");
 				UE_LOG(LogSpeckle, Warning, TEXT("%s"), *Message);
 			}
 			

--- a/Source/SpeckleUnreal/Private/API/SpeckleSerializer.cpp
+++ b/Source/SpeckleUnreal/Private/API/SpeckleSerializer.cpp
@@ -24,9 +24,9 @@ UBase* USpeckleSerializer::DeserializeBase(const TSharedPtr<FJsonObject> Obj,
 	}
 		
 	FString SpeckleType;	
-	if (!Obj->TryGetStringField("speckle_type", SpeckleType)) return nullptr;
+	if (!Obj->TryGetStringField(TEXT("speckle_type"), SpeckleType)) return nullptr;
 	FString ObjectId = "";	
-	Obj->TryGetStringField("id", ObjectId);
+	Obj->TryGetStringField(TEXT("id"), ObjectId);
 		
 	TSubclassOf<UBase> BaseType;
 	
@@ -62,7 +62,7 @@ UBase* USpeckleSerializer::DeserializeBase(const TSharedPtr<FJsonObject> Obj,
 		}
 		
 		//If we couldn't even deserialize this to a Base, something is quite wrong...
-		if(WorkingType == "Base" || BaseType == UBase::StaticClass())
+		if(WorkingType == TEXT("Base") || BaseType == UBase::StaticClass())
 		{
 			UE_LOG(LogSpeckle, Warning, TEXT("Skipping deserilization of %s id: %s - object could not be deserilaized to Base"), *SpeckleType, *ObjectId );
 			return nullptr;

--- a/Source/SpeckleUnreal/Private/Objects/Collection.cpp
+++ b/Source/SpeckleUnreal/Private/Objects/Collection.cpp
@@ -9,12 +9,12 @@ bool UCollection::Parse(const TSharedPtr<FJsonObject> Obj, const TScriptInterfac
 	if(!Super::Parse(Obj, ReadTransport)) return false;
 
 	// Parse Name property
-	if(!Obj->TryGetStringField("name", Name)) return false;
-	//DynamicProperties.Remove("name"); //Don't remove from dynamic, as we pick this up to name the actor
+	if(!Obj->TryGetStringField(TEXT("name"), Name)) return false;
+	//DynamicProperties.Remove(TEXT("name")); //Don't remove from dynamic, as we pick this up to name the actor
 
 	// Parse collectionType
-	if(!Obj->TryGetStringField("collectionType", CollectionType)) return false;
-	DynamicProperties.Remove("collectionType");
+	if(!Obj->TryGetStringField(TEXT("collectionType"), CollectionType)) return false;
+	DynamicProperties.Remove(TEXT("collectionType"));
 	
 	return true;
 }

--- a/Source/SpeckleUnreal/Private/Objects/Geometry/Mesh.cpp
+++ b/Source/SpeckleUnreal/Private/Objects/Geometry/Mesh.cpp
@@ -14,7 +14,7 @@ bool UMesh::Parse(const TSharedPtr<FJsonObject> Obj, const TScriptInterface<ITra
 	if(USpeckleObjectUtils::TryParseTransform(Obj, Transform))
 	{
 		Transform.ScaleTranslation(FVector(ScaleFactor));
-		DynamicProperties.Remove("transform");
+		DynamicProperties.Remove(TEXT("transform"));
 	}
 	else
 	{
@@ -24,7 +24,7 @@ bool UMesh::Parse(const TSharedPtr<FJsonObject> Obj, const TScriptInterface<ITra
 
 	//Parse Vertices
 	{
-		TArray<TSharedPtr<FJsonValue>> ObjectVertices = USpeckleObjectUtils::CombineChunks(Obj->GetArrayField("vertices"), ReadTransport);
+		TArray<TSharedPtr<FJsonValue>> ObjectVertices = USpeckleObjectUtils::CombineChunks(Obj->GetArrayField(TEXT("vertices")), ReadTransport);
 		const int32 NumberOfVertices = ObjectVertices.Num() / 3;
 
 		Vertices.Reserve(NumberOfVertices);
@@ -38,24 +38,24 @@ bool UMesh::Parse(const TSharedPtr<FJsonObject> Obj, const TScriptInterface<ITra
 				ObjectVertices[j + 2].Get()->AsNumber()
 			) * ScaleFactor );
 		}
-		DynamicProperties.Remove("vertices");
+		DynamicProperties.Remove(TEXT("vertices"));
 	}
 
 	//Parse Faces
 	{
-		const TArray<TSharedPtr<FJsonValue>> FaceVertices = USpeckleObjectUtils::CombineChunks(Obj->GetArrayField("faces"), ReadTransport);
+		const TArray<TSharedPtr<FJsonValue>> FaceVertices = USpeckleObjectUtils::CombineChunks(Obj->GetArrayField(TEXT("faces")), ReadTransport);
 		Faces.Reserve(FaceVertices.Num());
 		for(const auto& VertIndex : FaceVertices)
 		{
 			Faces.Add(VertIndex->AsNumber());
 		}
-		DynamicProperties.Remove("faces");
+		DynamicProperties.Remove(TEXT("faces"));
 	}
 
 	//Parse TextureCoords
 	{
 		const TArray<TSharedPtr<FJsonValue>>* TextCoordArray;
-		if(Obj->TryGetArrayField("textureCoordinates", TextCoordArray))
+		if(Obj->TryGetArrayField(TEXT("textureCoordinates"), TextCoordArray))
 		{
 			TArray<TSharedPtr<FJsonValue>> TexCoords = USpeckleObjectUtils::CombineChunks(*TextCoordArray, ReadTransport);
 	
@@ -69,14 +69,14 @@ bool UMesh::Parse(const TSharedPtr<FJsonObject> Obj, const TScriptInterface<ITra
 					TexCoords[i + 1].Get()->AsNumber()
 				)); 
 			}
-			DynamicProperties.Remove("textureCoordinates");
+			DynamicProperties.Remove(TEXT("textureCoordinates"));
 		}
 	}
 
 	//Parse VertexColors
 	{
 		const TArray<TSharedPtr<FJsonValue>>* ColorArray;
-		if(Obj->TryGetArrayField("colors", ColorArray))
+		if(Obj->TryGetArrayField(TEXT("colors"), ColorArray))
 		{
 			TArray<TSharedPtr<FJsonValue>> Colors = USpeckleObjectUtils::CombineChunks(*ColorArray, ReadTransport);
 	
@@ -86,16 +86,16 @@ bool UMesh::Parse(const TSharedPtr<FJsonObject> Obj, const TScriptInterface<ITra
 			{
 				VertexColors.Add(FColor(Colors[i].Get()->AsNumber()));
 			}
-			DynamicProperties.Remove("colors");
+			DynamicProperties.Remove(TEXT("colors"));
 		}
 	}
 
 	//Parse Optional RenderMaterial
-	if (Obj->HasField("renderMaterial"))
+	if (Obj->HasField(TEXT("renderMaterial")))
 	{
 		RenderMaterial = NewObject<URenderMaterial>();
-		RenderMaterial->Parse(Obj->GetObjectField("renderMaterial"), ReadTransport);
-		DynamicProperties.Remove("renderMaterial");
+		RenderMaterial->Parse(Obj->GetObjectField(TEXT("renderMaterial")), ReadTransport);
+		DynamicProperties.Remove(TEXT("renderMaterial"));
 	}
 	
 	AlignVerticesWithTexCoordsByIndex();

--- a/Source/SpeckleUnreal/Private/Objects/Geometry/PointCloud.cpp
+++ b/Source/SpeckleUnreal/Private/Objects/Geometry/PointCloud.cpp
@@ -12,7 +12,7 @@ bool UPointCloud::Parse(const TSharedPtr<FJsonObject> Obj, const TScriptInterfac
 
 	//Parse Points
 	{
-		TArray<TSharedPtr<FJsonValue>> ObjectPoints = USpeckleObjectUtils::CombineChunks(Obj->GetArrayField("points"), ReadTransport);
+		TArray<TSharedPtr<FJsonValue>> ObjectPoints = USpeckleObjectUtils::CombineChunks(Obj->GetArrayField(TEXT("points")), ReadTransport);
 		
 		Points.Reserve(ObjectPoints.Num() / 3);
 		for (int32 i = 2; i < ObjectPoints.Num(); i += 3) 
@@ -30,7 +30,7 @@ bool UPointCloud::Parse(const TSharedPtr<FJsonObject> Obj, const TScriptInterfac
 	
 	//Parse Colors
 	{
-		TArray<TSharedPtr<FJsonValue>> ObjectColors = USpeckleObjectUtils::CombineChunks(Obj->GetArrayField("colors"), ReadTransport);
+		TArray<TSharedPtr<FJsonValue>> ObjectColors = USpeckleObjectUtils::CombineChunks(Obj->GetArrayField(TEXT("colors")), ReadTransport);
 		
 		Colors.Reserve(ObjectColors.Num());
 		for (int32 i = 0; i < ObjectColors.Num(); i += 1) 
@@ -42,7 +42,7 @@ bool UPointCloud::Parse(const TSharedPtr<FJsonObject> Obj, const TScriptInterfac
 
 	//Parse Sizes
 	{
-		TArray<TSharedPtr<FJsonValue>> ObjectSizes = USpeckleObjectUtils::CombineChunks(Obj->GetArrayField("sizes"), ReadTransport);
+		TArray<TSharedPtr<FJsonValue>> ObjectSizes = USpeckleObjectUtils::CombineChunks(Obj->GetArrayField(TEXT("sizes")), ReadTransport);
 		
 		Sizes.Reserve(ObjectSizes.Num());
 		for (int32 i = 0; i < ObjectSizes.Num(); i += 1) 

--- a/Source/SpeckleUnreal/Private/Objects/Other/BlockInstance.cpp
+++ b/Source/SpeckleUnreal/Private/Objects/Other/BlockInstance.cpp
@@ -15,27 +15,27 @@ bool UBlockInstance::Parse(const TSharedPtr<FJsonObject> Obj,  const TScriptInte
 	//Transform
 	if(!USpeckleObjectUtils::TryParseTransform(Obj, Transform)) return false;
 	Transform.ScaleTranslation(FVector(ScaleFactor));
-	DynamicProperties.Remove("Transform");
+	DynamicProperties.Remove(TEXT("Transform"));
 	
 
 	//Geometries
 	//NOTE: This logic differs greatly from sharp/py implementations
 	const TSharedPtr<FJsonObject>* DefPtr;
-	if(!(Obj->TryGetObjectField("definition", DefPtr) || Obj->TryGetObjectField("blockDefinition", DefPtr) )) return false;
+	if(!(Obj->TryGetObjectField(TEXT("definition"), DefPtr) || Obj->TryGetObjectField(TEXT("blockDefinition"), DefPtr) )) return false;
 	
-	const FString RefID = DefPtr->operator->()->GetStringField("referencedId");
+	const FString RefID = DefPtr->operator->()->GetStringField(TEXT("referencedId"));
 	const TSharedPtr<FJsonObject> Definition = ReadTransport->GetSpeckleObject(RefID);
 	
-	if(!Obj->TryGetStringField("name", Name))
+	if(!Obj->TryGetStringField(TEXT("name"), Name))
 	{
-		if(Definition->TryGetStringField("name", Name))
+		if(Definition->TryGetStringField(TEXT("name"), Name))
 		{
 			//The instance has no name, so we'll steal it from the definition
-			DynamicProperties.Add("name", Definition->TryGetField("name"));
+			DynamicProperties.Add(TEXT("name"), Definition->TryGetField(TEXT("name")));
 		}
 	}
 
-	const auto Geometries = Definition->GetArrayField("geometry");
+	const auto Geometries = Definition->GetArrayField(TEXT("geometry"));
 
 	if(Geometries.Num() <= 0)
 	{
@@ -46,7 +46,7 @@ bool UBlockInstance::Parse(const TSharedPtr<FJsonObject> Obj,  const TScriptInte
 	for(const auto& Geo : Geometries)
 	{
 		const TSharedPtr<FJsonObject> MeshReference = Geo->AsObject();
-		const FString ChildId = MeshReference->GetStringField("referencedId");
+		const FString ChildId = MeshReference->GetStringField(TEXT("referencedId"));
 
 		if(ReadTransport->HasObject(ChildId))
 		{
@@ -56,11 +56,11 @@ bool UBlockInstance::Parse(const TSharedPtr<FJsonObject> Obj,  const TScriptInte
 		}
 		else UE_LOG(LogSpeckle, Warning, TEXT("Block definition references an unknown object id: %s"), *ChildId)
 	}
-	DynamicProperties.Remove("geometry");
+	DynamicProperties.Remove(TEXT("geometry"));
 	
 	// Intentionally don't remove blockDefinition from dynamic properties,
 	// because we want the converter to create the child geometries for us
-	//DynamicProperties.Remove("blockDefinition");
+	//DynamicProperties.Remove(TEXT("blockDefinition"));
 	
 	return true;
 	

--- a/Source/SpeckleUnreal/Private/Objects/Other/View3D.cpp
+++ b/Source/SpeckleUnreal/Private/Objects/Other/View3D.cpp
@@ -10,26 +10,26 @@ bool UView3D::Parse(const TSharedPtr<FJsonObject> Obj, const TScriptInterface<IT
 	const float ScaleFactor = USpeckleObjectUtils::ParseScaleFactor(Units);
 
 	// Parse optional Name property
-	if(Obj->TryGetStringField("name", Name)) { }
+	if(Obj->TryGetStringField(TEXT("name"), Name)) { }
 	
 	// Parse Origin
-	if(!USpeckleObjectUtils::ParseVectorProperty(Obj, "origin", ReadTransport, Origin)) return false;
+	if(!USpeckleObjectUtils::ParseVectorProperty(Obj, TEXT("origin"), ReadTransport, Origin)) return false;
 	Origin *= ScaleFactor;
-	DynamicProperties.Remove("origin");
+	DynamicProperties.Remove(TEXT("origin"));
 
 	// Parse UpDirection
 	if(!USpeckleObjectUtils::ParseVectorProperty(Obj, "upDirection", ReadTransport, UpDirection)) return false;
 	UpDirection *= ScaleFactor;
-	DynamicProperties.Remove("upDirection");
+	DynamicProperties.Remove(TEXT("upDirection"));
 	
 	// Parse ForwardDirection
-	if(!USpeckleObjectUtils::ParseVectorProperty(Obj, "forwardDirection", ReadTransport, ForwardDirection)) return false;
+	if(!USpeckleObjectUtils::ParseVectorProperty(Obj, TEXT("forwardDirection"), ReadTransport, ForwardDirection)) return false;
 	ForwardDirection *= ScaleFactor;
-	DynamicProperties.Remove("forwardDirection");
+	DynamicProperties.Remove(TEXT("forwardDirection"));
 
 	// Parse IsOrthogonal
-	if(!Obj->TryGetBoolField("isOrthogonal", IsOrthogonal)) return false;
-	DynamicProperties.Remove("isOrthogonal");
+	if(!Obj->TryGetBoolField(TEXT("isOrthogonal"), IsOrthogonal)) return false;
+	DynamicProperties.Remove(TEXT("isOrthogonal"));
 	
 	return true;
 }

--- a/Source/SpeckleUnreal/Private/Objects/Utils/SpeckleObjectUtils.cpp
+++ b/Source/SpeckleUnreal/Private/Objects/Utils/SpeckleObjectUtils.cpp
@@ -17,12 +17,12 @@ TArray<TSharedPtr<FJsonValue>> USpeckleObjectUtils::CombineChunks(const TArray<T
 	for(int32 i = 0; i < ArrayField.Num(); i++) 
 	{
 		FString Index;
-		if(ArrayField[i]->AsObject()->TryGetStringField("referencedId", Index))
+		if(ArrayField[i]->AsObject()->TryGetStringField(TEXT("referencedId"), Index))
 		{
 			if(!ensureAlwaysMsgf(Transport->HasObject(Index), TEXT("Failed to Dechunk array, Could not find chunk %s in transport"), *Index))
 				continue;
 			
-			const auto Chunk = Transport->GetSpeckleObject(Index)->GetArrayField("data");;
+			const auto Chunk = Transport->GetSpeckleObject(Index)->GetArrayField(TEXT("data"));;
 			ObjectPoints.Append(Chunk);
 		}
 		else
@@ -38,9 +38,9 @@ bool USpeckleObjectUtils::ResolveReference(const TSharedPtr<FJsonObject> Object,
 	FString SpeckleType;	
 	FString ReferenceID;
 
-	if (Object->TryGetStringField("speckle_type", SpeckleType)
-		&& SpeckleType == "reference"
-		&& Object->TryGetStringField("referencedId",ReferenceID))
+	if (Object->TryGetStringField(TEXT("speckle_type"), SpeckleType)
+		&& SpeckleType == TEXT("reference")
+		&& Object->TryGetStringField(TEXT("referencedId"),ReferenceID))
 	{
 		check(Transport != nullptr && Transport.GetObject() != nullptr)
 		
@@ -96,10 +96,10 @@ bool USpeckleObjectUtils::TryParseTransform(const TSharedPtr<FJsonObject> Speckl
 	const TSharedPtr<FJsonObject>* TransformObject;
 	const TArray<TSharedPtr<FJsonValue>>* TransformData;
 		
-	if(SpeckleObject->TryGetArrayField("transform", TransformData)) //Handle transform as array
+	if(SpeckleObject->TryGetArrayField(TEXT("transform"), TransformData)) //Handle transform as array
 	{ }
-	else if(SpeckleObject->TryGetObjectField("transform", TransformObject)
-		&& (*TransformObject)->TryGetArrayField("matrix", TransformData)) //Handle transform as object
+	else if(SpeckleObject->TryGetObjectField(TEXT("transform"), TransformObject)
+		&& (*TransformObject)->TryGetArrayField(TEXT("matrix"), TransformData)) //Handle transform as object
 	{ }
 	else return false;
 		
@@ -136,9 +136,9 @@ bool USpeckleObjectUtils::ParseVector(const TSharedPtr<FJsonObject> Object,
 	
 	double x = 0, y = 0, z = 0;
 	
-	if(!(Obj->TryGetNumberField("x", x)
-		&& Obj->TryGetNumberField("y", y)
-		&& Obj->TryGetNumberField("z", z))) return false;
+	if(!(Obj->TryGetNumberField(TEXT("x"), x)
+		&& Obj->TryGetNumberField(TEXT("y"), y)
+		&& Obj->TryGetNumberField(TEXT("z"), z))) return false;
 
 	OutObject = FVector(x,y,z);
 	//return true;
@@ -151,7 +151,7 @@ template <typename TBase>
 bool USpeckleObjectUtils::ParseSpeckleObject(const TSharedPtr<FJsonObject> Object,
 	const TScriptInterface<ITransport> Transport, TBase*& OutObject)
 {
-	static_assert(TIsDerivedFrom<TBase, UBase>::IsDerived, "Type TBase must inherit UBase");
+	static_assert(TIsDerivedFrom<TBase, UBase>::IsDerived, TEXT("Type TBase must inherit UBase"));
 
 	TSharedPtr<FJsonObject> Obj;
 	if(!ResolveReference(Object, Transport, Obj)) Obj = Object;
@@ -179,9 +179,9 @@ FString USpeckleObjectUtils::DisplayAsString(const FString& msg, const TSharedPt
 FString USpeckleObjectUtils::GetFriendlyObjectName(const UBase* SpeckleObject)
 {
 	FString Prefix;
-	if(!(SpeckleObject->TryGetDynamicString("name", Prefix)
-		|| SpeckleObject->TryGetDynamicString("Name", Prefix)
-		|| SpeckleObject->TryGetDynamicString("Family", Prefix)))
+	if(!(SpeckleObject->TryGetDynamicString(TEXT("name"), Prefix)
+		|| SpeckleObject->TryGetDynamicString(TEXT("Name"), Prefix)
+		|| SpeckleObject->TryGetDynamicString(TEXT("Family"), Prefix)))
 	{
 		Prefix = UObjectModelRegistry::GetSimplifiedTypeName(SpeckleObject->SpeckleType);
 	}

--- a/Source/SpeckleUnreal/Private/SpeckleUnrealManager.cpp
+++ b/Source/SpeckleUnreal/Private/SpeckleUnrealManager.cpp
@@ -55,7 +55,7 @@ void ASpeckleUnrealManager::Receive()
 	const FString StreamId = ReceiveSelection->StreamId;
 	const FString ObjectId = ReceiveSelection->ObjectId;
 	
-	FAnalytics::TrackEvent( ServerUrl, "NodeRun", TMap<FString, FString> { {"name", StaticClass()->GetName() }, {"worldType", FString::FromInt(GetWorld()->WorldType)}});
+	FAnalytics::TrackEvent( ServerUrl, TEXT("NodeRun"), TMap<FString, FString> { {TEXT("name"), StaticClass()->GetName() }, {TEXT("worldType"), FString::FromInt(GetWorld()->WorldType)}});
 	FString Message = FString::Printf(TEXT("Fetching Objects from Speckle Server: %s"), *ServerUrl);
 	PrintMessage(Message);
 
@@ -104,7 +104,7 @@ void ASpeckleUnrealManager::HandleReceive(TSharedPtr<FJsonObject> RootObject, bo
 	else
 	{
 		FString Id;
-		RootObject->TryGetStringField("id", Id);
+		RootObject->TryGetStringField(TEXT("id"), Id);
 		FString Message = FString::Printf(TEXT("Failed to deserialise root object: %s"), *Id);
 		HandleError(Message);
 	}

--- a/Source/SpeckleUnreal/Private/Tests/ReceiveSelectionComponentTest.cpp
+++ b/Source/SpeckleUnreal/Private/Tests/ReceiveSelectionComponentTest.cpp
@@ -64,6 +64,7 @@ bool FReceiveSelectionComponentTest::RunTest(const FString& Parameters)
 	ADD_LATENT_AUTOMATION_COMMAND(FCheckValidSelection(this, s));
 	ADD_LATENT_AUTOMATION_COMMAND(FCheckLimitMatch(this, s));
 
+	return true;
 	
 #else
 	TestTrue(TEXT("TEST_AUTH_TOKEN definition exists"), false);
@@ -71,7 +72,6 @@ bool FReceiveSelectionComponentTest::RunTest(const FString& Parameters)
 	return false;
 #endif
 	
-	return true;
 }
 #endif
 

--- a/Source/SpeckleUnreal/Private/Transports/ServerTransport.cpp
+++ b/Source/SpeckleUnreal/Private/Transports/ServerTransport.cpp
@@ -35,7 +35,7 @@ void UServerTransport::HandleRootObjectResponse(const FString& RootObjSerialized
 	TSharedPtr<FJsonObject> RootObj;
 	if(!LoadJson(RootObjSerialized, RootObj))
 	{
-		FString Message = FString::Printf( TEXT("A Root Object %s was recieved but was invalid and could not be deserialied"), *ObjectId);
+		FString Message = FString::Printf(TEXT("A Root Object %s was recieved but was invalid and could not be deserialied"), *ObjectId);
 		InvokeOnError(Message);
 		return;
 	}
@@ -43,7 +43,7 @@ void UServerTransport::HandleRootObjectResponse(const FString& RootObjSerialized
 	TargetTransport->SaveObject(ObjectId, RootObj);	
 	
 	// Find children are not already in the target transport
-	const auto Closures = RootObj->GetObjectField("__closure")->Values;
+	const auto Closures = RootObj->GetObjectField(TEXT("__closure"))->Values;
 	
 	TArray<FString> ChildrenIds; 
 	Closures.GetKeys(ChildrenIds);
@@ -71,13 +71,13 @@ void UServerTransport::CopyObjectAndChildren(const FString& ObjectId,
 	// Create Request for Root Object
 	const FHttpRequestRef Request = FHttpModule::Get().CreateRequest();
 	const FString Endpoint = FString::Printf(TEXT("%s/objects/%s/%s/single"), *ServerUrl, *StreamId, *ObjectId);
-	Request->SetVerb("GET");
+	Request->SetVerb(TEXT("GET"));
 	Request->SetURL(Endpoint);
-	Request->SetHeader("Accept", TEXT("text/plain"));
+	Request->SetHeader(TEXT("Accept"), TEXT("text/plain"));
 	if(!AuthToken.IsEmpty())
-		Request->SetHeader("Authorization","Bearer " + AuthToken);
-	Request->SetHeader("apollographql-client-name", "Unreal Engine");
-	Request->SetHeader("apollographql-client-version", SPECKLE_CONNECTOR_VERSION);
+		Request->SetHeader(TEXT("Authorization"),FString::Printf(TEXT("Bearer %s"), *AuthToken));
+	Request->SetHeader(TEXT("apollographql-client-name"), TEXT("Unreal Engine"));
+	Request->SetHeader(TEXT("apollographql-client-version"), SPECKLE_CONNECTOR_VERSION);
 		
 	// Response Callback
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
@@ -159,12 +159,12 @@ void UServerTransport::FetchChildren(TScriptInterface<ITransport> TargetTranspor
 	const FHttpRequestRef Request = FHttpModule::Get().CreateRequest();
 	{
 		const FString EndPoint = FString::Printf(TEXT("%s/api/getobjects/%s"), *ServerUrl, *StreamId);
-		Request->SetVerb("POST");
+		Request->SetVerb(TEXT("POST"));
 		Request->SetURL(EndPoint);
-		Request->SetHeader("Accept", TEXT("text/plain"));
+		Request->SetHeader(TEXT("Accept"), TEXT("text/plain"));
 		if(!AuthToken.IsEmpty())
-			Request->SetHeader("Authorization","Bearer " + AuthToken);
-		Request->SetHeader("Content-Type", "application/json");
+			Request->SetHeader(TEXT("Authorization"), FString::Printf(TEXT("Bearer %s"), *AuthToken));
+		Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
 		Request->SetContentAsString(Body);
 	}
 	

--- a/Source/SpeckleUnreal/Public/Objects/Base.h
+++ b/Source/SpeckleUnreal/Public/Objects/Base.h
@@ -51,16 +51,16 @@ public:
 	{
 		bool IsValid = false;
 		DynamicProperties = Obj->Values;
-		if(Obj->TryGetStringField("id", Id))
+		if(Obj->TryGetStringField(TEXT("id"), Id))
 		{
 			IsValid = true;
-			DynamicProperties.Remove("id");
+			DynamicProperties.Remove(TEXT("id"));
 		}
 		
-		if(Obj->TryGetStringField("units", Units)) DynamicProperties.Remove("units");
-		if(Obj->TryGetStringField("speckle_type", SpeckleType)) DynamicProperties.Remove("speckle_type");
-		if(Obj->TryGetStringField("applicationId", ApplicationId)) DynamicProperties.Remove("applicationId");
-		if(Obj->TryGetNumberField("totalChildrenCount", TotalChildrenCount)) DynamicProperties.Remove("totalChildrenCount");
+		if(Obj->TryGetStringField(TEXT("units"), Units)) DynamicProperties.Remove(TEXT("units"));
+		if(Obj->TryGetStringField(TEXT("speckle_type"), SpeckleType)) DynamicProperties.Remove(TEXT("speckle_type"));
+		if(Obj->TryGetStringField(TEXT("applicationId"), ApplicationId)) DynamicProperties.Remove(TEXT("applicationId"));
+		if(Obj->TryGetNumberField(TEXT("totalChildrenCount"), TotalChildrenCount)) DynamicProperties.Remove(TEXT("totalChildrenCount"));
 
 		return IsValid;
 	}

--- a/Source/SpeckleUnreal/Public/Objects/Other/RenderMaterial.h
+++ b/Source/SpeckleUnreal/Public/Objects/Other/RenderMaterial.h
@@ -40,25 +40,25 @@ public:
 	{
 		if(!Super::Parse(Obj, ReadTransport)) return false;
 	
-		if(!Obj->TryGetStringField("name", Name)) return false;
-		if(Obj->TryGetNumberField("opacity", Opacity)) DynamicProperties.Remove("opacity");
-		if(Obj->TryGetNumberField("metalness", Metalness)) DynamicProperties.Remove("metalness");
-		if(Obj->TryGetNumberField("roughness", Roughness)) DynamicProperties.Remove("roughness");
+		if(!Obj->TryGetStringField(TEXT("name"), Name)) return false;
+		if(Obj->TryGetNumberField(TEXT("opacity"), Opacity)) DynamicProperties.Remove(TEXT("opacity"));
+		if(Obj->TryGetNumberField(TEXT("metalness"), Metalness)) DynamicProperties.Remove(TEXT("metalness"));
+		if(Obj->TryGetNumberField(TEXT("roughness"), Roughness)) DynamicProperties.Remove(TEXT("roughness"));
 
 		bool IsValid = false;
 		
 		int32 ARGB;
-		if(Obj->TryGetNumberField("diffuse", ARGB))
+		if(Obj->TryGetNumberField(TEXT("diffuse"), ARGB))
 		{
 			Diffuse = FColor(ARGB);
-			DynamicProperties.Remove("diffuse");
+			DynamicProperties.Remove(TEXT("diffuse"));
 			IsValid = true;
 		}
 		
-		if(Obj->TryGetNumberField("emissive", ARGB))
+		if(Obj->TryGetNumberField(TEXT("emissive"), ARGB))
 		{
 			Emissive = FColor(ARGB);
-			DynamicProperties.Remove("emissive");
+			DynamicProperties.Remove(TEXT("emissive"));
 		}
 
 		return IsValid;


### PR DESCRIPTION
Unreal 5.4 seems to be far more strict about avoiding ANSI literals
see https://dev.epicgames.com/documentation/en-us/unreal-engine/character-encoding-in-unreal-engine

![Capture](https://github.com/specklesystems/speckle-unreal/assets/45512892/68cc0996-374d-4281-8ccb-5ba61ef6ae45)
